### PR TITLE
Follow PSR-16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,12 @@
     },
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^6.3"
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^6.3",
+        "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.4"
+        "phpunit/phpunit": "^7.4",
+        "symfony/cache": "^4.1"
     }
 }

--- a/src/Api/MarketingCloud/Contact.php
+++ b/src/Api/MarketingCloud/Contact.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oowlish\Salesforce\Api\MarketingCloud;
+
+use Oowlish\Salesforce\Api\Resource;
+
+class Contact extends Resource
+{
+    public function getSchemasCollection()
+    {
+        return $this->marketingCloud->request('GET', '/contacts/v1/schema');
+    }
+}

--- a/src/Api/Resource.php
+++ b/src/Api/Resource.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace Oowlish\Salesforce\Api;
 
-abstract class AbstractEndpoint
+use Oowlish\Salesforce\MarketingCloud;
+
+abstract class Resource
 {
-    /**
-     * @return string
-     */
-    abstract public function getHttpMethod(): string;
+    protected $marketingCloud;
 
-    /**
-     * @return string
-     */
-    abstract public function getURI(): string;
-
-    /**
-     * @return array
-     */
-    abstract public function getBody(): array;
+    public function __construct(MarketingCloud $marketingCloud)
+    {
+        $this->marketingCloud = $marketingCloud;
+    }
 }

--- a/src/Api/Resource.php
+++ b/src/Api/Resource.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oowlish\Salesforce\Endpoints;
+namespace Oowlish\Salesforce\Api;
 
 abstract class AbstractEndpoint
 {


### PR DESCRIPTION
It's necessary to save the token to inject on each **http** request. But, exists an important point because the token needed to be shared between servers. Using the [PSR-16](https://www.php-fig.org/psr/psr-16/) was possible to solve this and to ensure the interoperability on the clusters.

- https://www.php-fig.org/psr/psr-16/
- https://symfony.com/doc/3.4/components/cache.html
it was used the [Symfony Cache Component](https://symfony.com/doc/3.4/components/cache.html) on the test environment