### PR TITLE
seding a triggered email

### DIFF
--- a/src/Api/MarketingCloud/Messaging.php
+++ b/src/Api/MarketingCloud/Messaging.php
@@ -16,6 +16,7 @@ class Messaging extends Resource
      * @param array $from
      * @param array $to
      * @param array $options
+     *
      * @return array
      */
     public function sendEmail(string $triggeredSendDefinitionId, array $from, array $to, array $options): array

--- a/src/Api/MarketingCloud/Messaging.php
+++ b/src/Api/MarketingCloud/Messaging.php
@@ -28,7 +28,7 @@ class Messaging extends Resource
                 [
                     $from,
                     $to,
-                    $options
+                    $options,
                 ]
             );
     }

--- a/src/Api/MarketingCloud/Messaging.php
+++ b/src/Api/MarketingCloud/Messaging.php
@@ -19,7 +19,7 @@ class Messaging extends Resource
      *
      * @return array
      */
-    public function sendEmail(string $triggeredSendDefinitionId, array $from, array $to, array $options): array
+    public function sendEmail(string $triggeredSendDefinitionId, array $from, array $to, array $options = []): array
     {
         return $this
             ->marketingCloud
@@ -29,7 +29,7 @@ class Messaging extends Resource
                 [
                     $from,
                     $to,
-                    $options,
+                    ['Options' => $options],
                 ]
             );
     }

--- a/src/Api/MarketingCloud/Messaging.php
+++ b/src/Api/MarketingCloud/Messaging.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oowlish\Salesforce\Api\MarketingCloud;
+
+use Oowlish\Salesforce\Api\Resource;
+
+class Messaging extends Resource
+{
+    /**
+     * Sends transactional email using Marketing Cloud's triggered send functionality.
+     * In order to use this service, configure a triggered send definition in Email Studio.
+     *
+     * @param string $triggeredSendDefinitionId
+     * @param array $from
+     * @param array $to
+     * @param array $options
+     * @return array
+     */
+    public function sendEmail(string $triggeredSendDefinitionId, array $from, array $to, array $options): array
+    {
+        return $this
+            ->marketingCloud
+            ->request(
+                'POST',
+                "/messaging/v1/messageDefinitionSends/{$triggeredSendDefinitionId}/send",
+                [
+                    $from,
+                    $to,
+                    $options
+                ]
+            );
+    }
+}

--- a/src/Api/MarketingCloud/Messaging.php
+++ b/src/Api/MarketingCloud/Messaging.php
@@ -13,9 +13,9 @@ class Messaging extends Resource
      * In order to use this service, configure a triggered send definition in Email Studio.
      *
      * @param string $triggeredSendDefinitionId
-     * @param array $from
-     * @param array $to
-     * @param array $options
+     * @param array  $from
+     * @param array  $to
+     * @param array  $options
      *
      * @return array
      */


### PR DESCRIPTION
I wrote more one method. The new method [send email](https://developer.salesforce.com/docs/atlas.en-us.mc-apis.meta/mc-apis/messageDefinitionSends.htm) using the Marketing Cloud API.